### PR TITLE
Provide full commit SHA for civetweb

### DIFF
--- a/docker-build
+++ b/docker-build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ ! $# -eq 1 ]; then
   echo "Usage: ./docker-build <project>" >&2
   exit 1

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -60,7 +60,7 @@ def smyte_workspace(workspace_name):
     native.new_git_repository(
         name = "civetweb_git",
         remote = "https://github.com/civetweb/civetweb.git",
-        commit = "85424a4",
+        commit = "85424a4ad51eadc7e0b5942cadff2869a3ea1d84",
         build_file = workspace_name + "//third_party:civetweb.BUILD"
     )
     native.bind(


### PR DESCRIPTION
Without the full commit SHA you get an error like:

Prefix civetweb-85424a4 was given, but not found in the archive

Relates to #3